### PR TITLE
Fix installer chrome-sandbox path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The installer:
 - Installs a wrapper at `/usr/local/bin/linear`, a desktop entry, and the Linear icon into the system icon cache.
 - Accepts overrides: `VERSION=0.2.5 APPIMAGE_URL=<url> INSTALL_ROOT=/opt ./installer.sh`
 
+Recent fix:
+- Removed a stale hardcoded `/opt/Linear/chrome-sandbox` step that could print a missing-file warning on successful installs.
+
 Development:
 - `npm start` launches Electron with sandbox disabled for local runs (packaged builds use the proper setuid helper).
 - `npm run build` produces an AppImage that bundles the Linear brand assets for the desktop icon.

--- a/installer.sh
+++ b/installer.sh
@@ -72,9 +72,5 @@ sudo install -Dm644 "${ICON_SVG}" /usr/share/icons/hicolor/scalable/apps/linear.
 sudo install -Dm644 "${ICON_PNG}" /usr/share/icons/hicolor/512x512/apps/linear.png
 sudo gtk-update-icon-cache -f /usr/share/icons/hicolor || true
 
-echo "Configuring chrome sandbox"
-
-sudo chown root:root /opt/Linear/chrome-sandbox || true
-sudo chmod 4755 /opt/Linear/chrome-sandbox || true
 
 echo "Linear ${VERSION} installed. Launch with: ${WRAPPER_PATH}"


### PR DESCRIPTION
## Summary
- remove stale hardcoded `/opt/Linear/chrome-sandbox` permission step
- keep sandbox configuration tied to extracted AppImage path
- document the fix in README

Co-Authored-By: Oz <oz-agent@warp.dev>